### PR TITLE
Remove trailing slash from ping.pub explorer

### DIFF
--- a/decentr/chain.json
+++ b/decentr/chain.json
@@ -131,7 +131,7 @@
         },
         {
             "kind": "ping.pub",
-            "url": "https://ping.pub/decentr/",
+            "url": "https://ping.pub/decentr",
             "tx_page": "https://ping.pub/decentr/tx/${txHash}"
         }
     ]


### PR DESCRIPTION
Fix for issue 669 -- https://github.com/eco-stake/restake-ui/issues/38